### PR TITLE
Removed doubled row div in form_login.ctp

### DIFF
--- a/app/View/Elements/form_login.ctp
+++ b/app/View/Elements/form_login.ctp
@@ -1,4 +1,3 @@
-<div class="row">
 	<div class="col-lg-4 col-lg-offset-4">
 		<?php echo $this->Form->create('User',array(
 												'url' => array(
@@ -25,4 +24,3 @@
 
 
 	</div>
-</div>


### PR DESCRIPTION
This element is only included in login.ctp and in that file there already is a ´div class="row"´. The double row results in an ugly mobile layout (input fields without padding)
